### PR TITLE
Fix ProjectImports.zip regression from shared FileUtilities statics

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -542,23 +542,22 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.BuildProjectExpectSuccess(project, binaryLogger);
         }
 
+        /// <summary>
+        /// Regression test for dotnet/dotnet#5433 — ClearCacheDirectory must not destroy the
+        /// ProjectImports archive before it is embedded in the binlog.
+        /// </summary>
         [Fact]
-        public void ProjectImportsCollectorArchiveSurvivesClearCacheDirectory()
+        public void BinlogEmbeddedImportsSurviveClearCacheDirectory()
         {
-            // Regression test: ProjectImportsCollector must store its temporary archive
-            // outside GetCacheDirectory() so that ClearCacheDirectory() does not destroy
-            // the zip before the BinaryLogger finishes embedding it.
             string logFilePath = Path.Combine(_env.DefaultTestDirectory.Path, "test.binlog");
 
             var collector = new ProjectImportsCollector(logFilePath, createFile: false, runOnBackground: false);
-
-            // Add some content so the archive is non-empty.
             collector.AddFileFromMemory("testfile.proj", "<Project />");
 
-            // Simulate the cleanup that XMake.cs performs after EndBuild.
+            // This is what XMake.cs does after EndBuild — wipes the cache directory.
             FileUtilities.ClearCacheDirectory();
 
-            // The collector should still be able to process and embed the archive.
+            // ProcessResult must still read the archive after the cache dir is gone.
             bool archiveRead = false;
             collector.ProcessResult(
                 stream =>
@@ -567,9 +566,9 @@ namespace Microsoft.Build.UnitTests
                     archiveRead = true;
                 },
                 error => throw new InvalidOperationException(error));
+            archiveRead.ShouldBeTrue("Archive must be readable after ClearCacheDirectory");
 
-            archiveRead.ShouldBeTrue("The ProjectImports archive should still be readable after ClearCacheDirectory");
-
+            // DeleteArchive must not throw (directory must still exist).
             collector.DeleteArchive();
 
             // Satisfy the fixture's expectation that _logFile exists.

--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -542,6 +542,40 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.BuildProjectExpectSuccess(project, binaryLogger);
         }
 
+        [Fact]
+        public void ProjectImportsCollectorArchiveSurvivesClearCacheDirectory()
+        {
+            // Regression test: ProjectImportsCollector must store its temporary archive
+            // outside GetCacheDirectory() so that ClearCacheDirectory() does not destroy
+            // the zip before the BinaryLogger finishes embedding it.
+            string logFilePath = Path.Combine(_env.DefaultTestDirectory.Path, "test.binlog");
+
+            var collector = new ProjectImportsCollector(logFilePath, createFile: false, runOnBackground: false);
+
+            // Add some content so the archive is non-empty.
+            collector.AddFileFromMemory("testfile.proj", "<Project />");
+
+            // Simulate the cleanup that XMake.cs performs after EndBuild.
+            FileUtilities.ClearCacheDirectory();
+
+            // The collector should still be able to process and embed the archive.
+            bool archiveRead = false;
+            collector.ProcessResult(
+                stream =>
+                {
+                    stream.Length.ShouldBeGreaterThan(0);
+                    archiveRead = true;
+                },
+                error => throw new InvalidOperationException(error));
+
+            archiveRead.ShouldBeTrue("The ProjectImports archive should still be readable after ClearCacheDirectory");
+
+            collector.DeleteArchive();
+
+            // Satisfy the fixture's expectation that _logFile exists.
+            File.WriteAllText(_logFile, string.Empty);
+        }
+
         /// <summary>
         /// Regression test for https://github.com/dotnet/msbuild/issues/6323.
         /// </summary>

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -63,10 +63,8 @@ namespace Microsoft.Build.Logging
             }
             else
             {
-                // Store the temporary archive in TempFileDirectory rather than GetCacheDirectory().
-                // GetCacheDirectory() is shared across all assemblies and is wiped by
-                // ClearCacheDirectory() during build shutdown in XMake, which can race with
-                // the logger still needing this file for embedding into the binlog.
+                // Store the temporary archive in TempFileDirectory rather than GetCacheDirectory()
+                // because ClearCacheDirectory() wipes the cache dir during build shutdown.
                 string tempDirectory = FileUtilities.TempFileDirectory;
 
                 _archiveFilePath = Path.Combine(

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -302,14 +302,8 @@ namespace Microsoft.Build.Logging
         {
             Close();
 
-            try
-            {
-                File.Delete(_archiveFilePath);
-            }
-            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
-            {
-                // Best effort — the archive may already have been cleaned up.
-            }
+            // Best effort — the archive may already have been cleaned up.
+            FileUtilities.DeleteNoThrow(_archiveFilePath);
         }
     }
 }

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -63,15 +63,14 @@ namespace Microsoft.Build.Logging
             }
             else
             {
-                string cacheDirectory = FileUtilities.GetCacheDirectory();
-                if (!FileSystems.Default.DirectoryExists(cacheDirectory))
-                {
-                    Directory.CreateDirectory(cacheDirectory);
-                }
+                // Store the temporary archive in TempFileDirectory rather than GetCacheDirectory().
+                // GetCacheDirectory() is shared across all assemblies and is wiped by
+                // ClearCacheDirectory() during build shutdown in XMake, which can race with
+                // the logger still needing this file for embedding into the binlog.
+                string tempDirectory = FileUtilities.TempFileDirectory;
 
-                // Archive file will be temporarily stored in MSBuild cache folder and deleted when no longer needed
                 _archiveFilePath = Path.Combine(
-                    cacheDirectory,
+                    tempDirectory,
                     GetArchiveFilePath(
                         Path.GetFileName(logFilePath),
                         sourcesArchiveExtension));
@@ -304,7 +303,15 @@ namespace Microsoft.Build.Logging
         public void DeleteArchive()
         {
             Close();
-            File.Delete(_archiveFilePath);
+
+            try
+            {
+                File.Delete(_archiveFilePath);
+            }
+            catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+            {
+                // Best effort — the archive may already have been cleaned up.
+            }
         }
     }
 }


### PR DESCRIPTION
## Fix

Fixes the scenario test failures reported in [dotnet/dotnet#5433](https://github.com/dotnet/dotnet/pull/5433) (codeflow for #13364).

### Problem

PR #13364 moved `FileUtilities` from `src/Shared/` (compiled into each assembly with **independent statics**) to `src/Framework/` (single shared assembly). Before that move, `ClearCacheDirectory()` in `XMake.cs` used MSBuild.exe's own `cacheDirectory` static — a separate, mostly-empty directory — so the call was effectively a no-op for the real build cache. After the move, all assemblies share one `cacheDirectory` static, so `ClearCacheDirectory()` now deletes the directory that `ProjectImportsCollector` uses for its temporary `ProjectImports.zip` archive.

This causes 9 scenario test failures across all platforms:
\\\
Unhandled exception: Could not find a part of the path
  '.../MSBuildTemp.../MSBuild<PID>-1/run-dotnet-run.ProjectImports.zip'
\\\

### Root Cause

| Before #13364 | After #13364 |
|---|---|
| Each assembly compiled its own `FileUtilities` with independent `cacheDirectory` / `TempFileDirectory` statics | All assemblies share one `FileUtilities` in Framework |
| `XMake.ClearCacheDirectory()` -> MSBuild.exe's cache dir (empty, no-op) | `XMake.ClearCacheDirectory()` -> shared cache dir (contains ProjectImports.zip!) |
| `ProjectImportsCollector` -> Build.dll's cache dir (untouched by XMake cleanup) | `ProjectImportsCollector` -> same shared cache dir (destroyed by XMake cleanup) |

### Fix

- **`ProjectImportsCollector.cs`**: Store the temporary archive in `TempFileDirectory` (the parent) instead of `GetCacheDirectory()` (the child subdirectory wiped by `ClearCacheDirectory()`). The archive is still cleaned up by `DeleteArchive()` after embedding and by the `ProcessExit` handler.
- **`ProjectImportsCollector.cs`**: Make `DeleteArchive()` resilient to IO errors (best-effort cleanup).
- **`BinaryLogger_Tests.cs`**: Regression test that verifies the archive remains readable after `ClearCacheDirectory()`.

### Open question

Before #13364, the `ClearCacheDirectory()` calls in `XMake.cs` were no-ops for the real result cache. Now they actually delete result cache files. This is probably fine (runs after `EndBuild`), but is a behavioral change worth validating -- especially for the `DiscardBuildResults=false` case where callers may expect disk-spilled results to survive.